### PR TITLE
refactor: TodoModel 클래스 분리 및 useSelectionList 훅 작성

### DIFF
--- a/src/components/todo/TodoContainer.vue
+++ b/src/components/todo/TodoContainer.vue
@@ -1,9 +1,11 @@
 <script setup>
-import { ref, computed, reactive, watch } from "vue";
+import { ref, computed, reactive, watch, unref } from "vue";
 import TodoHeader from "@/components/todo/TodoHeader.vue";
 import TodoInput from "@/components/todo/TodoInput.vue";
 import TodoList from "@/components/todo/TodoList.vue";
 import { todoStore } from "@/stores/TodoStore";
+import TodoModel from "@/models/TodoModel";
+import { useSelectionList } from "@/hooks/useSelectionList";
 
 class TodoFilter {
   constructor(id, text) {
@@ -40,18 +42,9 @@ const currentFilter = computed(() => {
   return filters.find((filter) => filter.id === currentFilterId.value);
 });
 
-const convertStoreTodo = (storeTodo) => {
-  return {
-    id: storeTodo.id,
-    content: storeTodo.content,
-    progress: storeTodo.progress,
-    selected: false,
-    until: new Date(storeTodo.until),
-    createdAt: new Date(storeTodo.createdAt),
-  };
-};
-
-const storedTodos = todoStore.selectAll().map((val) => convertStoreTodo(val));
+const storedTodos = todoStore
+  .selectAll()
+  .map((storeTodo) => TodoModel.fromSerialized(storeTodo));
 const allTodos = reactive(storedTodos);
 
 const displayTodos = computed(() => {
@@ -59,14 +52,12 @@ const displayTodos = computed(() => {
   return todos;
 });
 
-const selectedTodos = computed(() => {
-  return allTodos.filter((todo) => todo.selected);
-});
+const selectionList = useSelectionList(TodoModel.equals);
 
 // 필터 변경 시 선택 아이템 초기화
 watch(currentFilter, (current, old) => {
   if (current != old) {
-    allTodos.forEach((todo) => (todo.selected = false));
+    selectionList.clear();
   }
 });
 
@@ -74,9 +65,7 @@ watch(currentFilter, (current, old) => {
 watch(displayTodos, (current, old) => {
   if (current.length != old.length) {
     old.forEach((oldTodo) => {
-      if (!current.find((todo) => todo.id === oldTodo.id)) {
-        oldTodo.selected = false;
-      }
+      selectionList.unselect(oldTodo);
     });
   }
 });
@@ -86,15 +75,7 @@ const findTodoById = (todoId) => {
 };
 
 const createTodo = ({ content, until }) => {
-  const datetime = new Date();
-  const id = datetime.getTime();
-  const newTodo = {
-    id: id,
-    content: content,
-    progress: "wait",
-    until: until,
-    createdAt: datetime,
-  };
+  const newTodo = TodoModel.create({ content, until });
   allTodos.push(newTodo);
   todoStore.upsert(newTodo);
 };
@@ -103,7 +84,7 @@ const updateTodo = (todo, { content, until, progress }) => {
   if (content) todo.content = content;
   if (until) todo.until = until;
   if (progress) todo.progress = progress;
-  todoStore.update(todo);
+  todoStore.update(unref(todo));
 };
 
 const deleteTodo = (todo) => {
@@ -148,19 +129,23 @@ const handleEditTodo = (todoId, update) => {
 const handleSelectTodo = (todoId) => {
   const todo = findTodoById(todoId);
   if (!todo) return;
-  todo.selected = !todo.selected;
+  selectionList.toggle(todo);
 };
 
 const handleSelectMultiTodos = (todoIds, selected) => {
   todoIds.forEach((todoId) => {
     const todo = findTodoById(todoId);
     if (!todo) return;
-    todo.selected = selected;
+    if (selectionList.find(todo)) {
+      selectionList.unselect(todo);
+    } else {
+      selectionList.select(todo);
+    }
   });
 };
 
 const handleChangeSelectedTodos = (name, value) => {
-  const targetTodos = selectedTodos.value.slice();
+  const targetTodos = selectionList.items.value.slice();
   targetTodos.forEach((todo) => {
     const update = {};
     update[name] = value;
@@ -169,10 +154,10 @@ const handleChangeSelectedTodos = (name, value) => {
 };
 
 const handleDeleteSelectedTodos = () => {
-  const targetTodos = selectedTodos.value.slice();
+  const targetTodos = selectionList.items.value.slice();
   targetTodos.forEach((todo) => {
     deleteTodo(todo);
-    todo.selected = false;
+    selectionList.unselect(todo);
   });
 };
 </script>
@@ -186,7 +171,7 @@ const handleDeleteSelectedTodos = () => {
     />
     <TodoList
       :items="displayTodos"
-      :selectedItems="selectedTodos"
+      :selectedItems="selectionList.items"
       @toggle-todo-progress="handleToggleTodoProgress"
       @delete-todo="handleDeleteTodo"
       @edit-todo="handleEditTodo"

--- a/src/components/todo/TodoList.vue
+++ b/src/components/todo/TodoList.vue
@@ -14,11 +14,19 @@ const emit = defineEmits([
 
 const { items, selectedItems } = defineProps(["items", "selectedItems"]);
 
-const canMultiChange = computed(() => selectedItems.length > 0);
-const canMultiDelete = computed(() => selectedItems.length > 0);
+const canMultiChange = computed(() => selectedItems.value.length > 0);
+const canMultiDelete = computed(() => selectedItems.value.length > 0);
 const allSelected = () => {
   const anyUnselected = items.find((item) => item.selected === false);
   return !anyUnselected;
+};
+
+const isSelected = (item) => {
+  return (
+    selectedItems.value.findIndex(
+      (selectedItem) => item.id === selectedItem.id,
+    ) >= 0
+  );
 };
 
 const progressSelect = useTemplateRef("todo-progress-select");
@@ -52,7 +60,6 @@ const handleSelectAll = () => {
 
 const handleMultiProgressChange = ($e) => {
   const value = $e.target.value;
-  console.log(value);
   emit("change-selected-todos", "progress", value);
 };
 </script>
@@ -91,6 +98,7 @@ const handleMultiProgressChange = ($e) => {
         v-for="(item, idx) in items"
         :key="item.id"
         :todo="item"
+        :selected="isSelected(item)"
         @toggle-todo-progress="handleToggleTodoProgress"
         @delete-todo="handleDeleteTodo"
         @edit-todo="handleEditTodo"

--- a/src/components/todo/TodoListItem.vue
+++ b/src/components/todo/TodoListItem.vue
@@ -10,12 +10,13 @@ const emit = defineEmits([
   "select-todo",
 ]);
 
-const { todo } = defineProps({
+const { todo, selected } = defineProps({
   todo: {
     id: Number,
     content: String,
     progress: String,
   },
+  selected: Boolean,
 });
 
 const modifying = ref(false);
@@ -80,7 +81,7 @@ const handleCancelEdit = () => {
       <input
         type="checkbox"
         :id="`chk-${todo.id}`"
-        :checked="todo.selected"
+        :checked="selected"
         @input="handleSelectTodo"
       />
       <label
@@ -187,7 +188,7 @@ const handleCancelEdit = () => {
 }
 
 .todo-list-item-state > .ongoing {
-  color: powderblue;
+  color: royalblue;
 }
 
 .todo-list-item-state > .completed {

--- a/src/hooks/useSelectionList.js
+++ b/src/hooks/useSelectionList.js
@@ -1,0 +1,64 @@
+import { ref, unref } from "vue";
+
+export const useSelectionList = (equals) => {
+  const _selectedItems = ref([]);
+  const _equals = (a, b) => {
+    return equals(unref(a), unref(b));
+  };
+
+  const _findIndex = (item) => {
+    return _selectedItems.value.findIndex((selectedItem) =>
+      _equals(selectedItem, item),
+    );
+  };
+
+  const _exists = (item) => {
+    return _findIndex(item) >= 0;
+  };
+
+  const _find = (item) => {
+    return _selectedItems.value.find((selectedItem) =>
+      _equals(selectedItem, item),
+    );
+  };
+
+  const _select = (item) => {
+    if (!_exists(item)) {
+      _selectedItems.value.push(item);
+    }
+  };
+
+  const _unselect = (item) => {
+    const idx = _findIndex(item);
+    if (idx >= 0) {
+      _selectedItems.value.splice(idx, 1);
+    }
+  };
+
+  const _toggle = (item) => {
+    const idx = _findIndex(item);
+    if (idx >= 0) {
+      _selectedItems.value.splice(idx, 1);
+    } else {
+      _selectedItems.value.push(item);
+    }
+  };
+
+  const _clear = (item) => {
+    _selectedItems.value = [];
+  };
+
+  const _setSelectedItems = (items) => {
+    _selectedItems.value = items;
+  };
+
+  return {
+    items: _selectedItems,
+    set: _setSelectedItems,
+    find: _find,
+    select: _select,
+    unselect: _unselect,
+    toggle: _toggle,
+    clear: _clear,
+  };
+};

--- a/src/models/TodoModel.js
+++ b/src/models/TodoModel.js
@@ -1,0 +1,59 @@
+class TodoModel {
+  constructor(id, content, progress, until, createdAt) {
+    this.id = id;
+    this.content = content;
+    this.progress = progress;
+    this.until = until;
+    this.createdAt = createdAt;
+  }
+
+  static fromObject({ id, content, progress, until, createdAt }) {
+    return new TodoModel(id, content, progress, until, createdAt);
+  }
+
+  static create({ content, until }) {
+    const now = new Date();
+    const id = now.getTime();
+    return new TodoModel(id, content, "wait", new Date(until.getTime()), now);
+  }
+
+  serialize() {
+    return {
+      id: this.id,
+      content: this.content,
+      progress: this.progress,
+      until: this.until.getTime(),
+      createdAt: this.createdAt.getTime(),
+    };
+  }
+
+  static serialize(todo) {
+    return {
+      id: todo.id,
+      content: todo.content,
+      progress: todo.progress,
+      until: todo.until.getTime(),
+      createdAt: todo.createdAt.getTime(),
+    };
+  }
+
+  static fromSerialized(serializedTodo) {
+    return new TodoModel(
+      serializedTodo.id,
+      serializedTodo.content,
+      serializedTodo.progress,
+      new Date(serializedTodo.until),
+      new Date(serializedTodo.createdAt),
+    );
+  }
+
+  static equals(a, b) {
+    return a.id === b.id;
+  }
+
+  equals(other) {
+    return this._id === other.id;
+  }
+}
+
+export default TodoModel;

--- a/src/stores/TodoStore.js
+++ b/src/stores/TodoStore.js
@@ -17,7 +17,7 @@ export const todoStore = {
       console.log(`이미 저장된 객체입니다. [id=${todo.id}]`);
       return;
     }
-    store[todo.id] = this.toStoreData(todo);
+    store[todo.id] = todo.serialize();
     commit();
   },
   delete(todo) {
@@ -37,7 +37,7 @@ export const todoStore = {
       console.log(`존재하지 않는 객체입니다. [id=${todo.id}]`);
       return;
     }
-    store[todo.id] = this.toStoreData(todo);
+    store[todo.id] = todo.serialize();
     commit();
   },
   upsert(todo) {
@@ -54,15 +54,5 @@ export const todoStore = {
       arr.push({ ...val });
     });
     return arr;
-  },
-  // store에 저장하기 위한 형태로 변환
-  toStoreData(todo) {
-    return {
-      id: todo.id,
-      content: todo.content,
-      progress: todo.progress,
-      until: todo.until.getTime(),
-      createdAt: todo.createdAt.getTime(),
-    };
   },
 };


### PR DESCRIPTION
#9 요구사항 구현

- TodoModel 클래스 : TodoContainer에서 직접 Todo 아이템을 정의하여 사용하던 방식에서 TodoModel이라는 데이터 객체로 분리하고 TodoModel 기반으로 동작을 수행하도록 변경했습니다.
- useSelectionList 훅 : Todo 아이템의 selected 속성을 제거하고, 추상객체에 대한 선택 동작을 제공하는 useSelectionList 훅을 작성하여 Todo 아이템 선택을 처리하도록 했습니다.